### PR TITLE
Added Finalise Match feature

### DIFF
--- a/RealtyReachApi/Controllers/CustomerJobController.cs
+++ b/RealtyReachApi/Controllers/CustomerJobController.cs
@@ -19,10 +19,12 @@ namespace RealtyReachApi.Controllers
     public class CustomerJobController : ControllerBase
     {
         private readonly ICustomerJobService _customerJobService;
+        private readonly IMatchingService _matchingService;
 
-        public CustomerJobController(ICustomerJobService customerJobService)
+        public CustomerJobController(ICustomerJobService customerJobService, IMatchingService matchingService)
         {
             _customerJobService = customerJobService;
+            _matchingService = matchingService;
         }
 
         // GET: api/jobs/user/{userId}
@@ -40,7 +42,7 @@ namespace RealtyReachApi.Controllers
         }
 
         // GET: api/Jobs/{JobId}
-        [HttpGet("{JobId}")]
+        [HttpGet("{jobId}")]
         public async Task<ActionResult<JobDto>> GetJobById(int jobId)
         {
             var job = await _customerJobService.GetJobByIdAsync(jobId);
@@ -58,6 +60,13 @@ namespace RealtyReachApi.Controllers
         {
             var jobDto = await _customerJobService.CreateJobAsync(createJobDto, Guid.Parse(User.GetUserId()));
             return Ok();
+        }
+
+        [HttpPost("finalise")]
+        public async Task<ActionResult<MatchingJobDto>> FinalizeMatch(MatchingJobDto matchingJobDto)
+        {
+            var jobDto = await _matchingService.FinalizeMatchAsync(matchingJobDto);
+            return Ok(jobDto);
         }
 
         // PUT: api/Jobs/{JobId}

--- a/RealtyReachApi/Data/SharedDbContext.cs
+++ b/RealtyReachApi/Data/SharedDbContext.cs
@@ -15,6 +15,7 @@ namespace RealtyReachApi.Data
         public DbSet<Customer> Customers { get; set; }
         public DbSet<Professional?> Professionals { get; set; }
         public DbSet<ProfessionalType> ProfessionalTypes { get; set; }
+        public DbSet<JobProfessionalLink> JobProfessionalLinks {get; set;}
         
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/RealtyReachApi/Data/SharedDbContext.cs
+++ b/RealtyReachApi/Data/SharedDbContext.cs
@@ -15,7 +15,7 @@ namespace RealtyReachApi.Data
         public DbSet<Customer> Customers { get; set; }
         public DbSet<Professional?> Professionals { get; set; }
         public DbSet<ProfessionalType> ProfessionalTypes { get; set; }
-        public DbSet<JobProfessionalLink> JobProfessionalLinks {get; set;}
+        public DbSet<JobProfessionalLink> JobProfessionalLink {get; set;}
         
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/RealtyReachApi/Dtos/JobDTO.cs
+++ b/RealtyReachApi/Dtos/JobDTO.cs
@@ -35,8 +35,16 @@ public class CreateJobDto
 
     public required string JourneyProgress { get; set; }
 
-    // SelectedProfessionals are professionals that are chosen by the Customer via the frontend. I.e = They select ["Advocate", "Building and Pest"]
+    // SelectedProfessionals are professionals that are chosen by the Customer via the frontend. 
+    //I.e = They select ["Advocate", "Building and Pest"]
     public required string[] SelectedProfessionals { get; set; }
     public required Guid[] SuggestedProfessionalIds { get; set; }
     public string? AdditionalDetails { get; set; }
+}
+
+public class MatchingJobDto
+{
+    public required int JobId { get; set; }
+    public required Guid ProfessionalId { get; set; }
+
 }

--- a/RealtyReachApi/Models/Admin.cs
+++ b/RealtyReachApi/Models/Admin.cs
@@ -1,10 +1,8 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using TypeGen.Core.TypeAnnotations;
 
 namespace RealtyReachApi.Models;
-[ExportTsClass]
 public class Admin
 {
     public Guid Id { get; set; }

--- a/RealtyReachApi/Models/Customer.cs
+++ b/RealtyReachApi/Models/Customer.cs
@@ -1,10 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using TypeGen.Core.TypeAnnotations;
+
 
 namespace RealtyReachApi.Models;
-[ExportTsClass]
 public class Customer
 {
     public Guid Id { get; set; }

--- a/RealtyReachApi/Models/Job.cs
+++ b/RealtyReachApi/Models/Job.cs
@@ -1,11 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using TypeGen.Core.TypeAnnotations;
 
 namespace RealtyReachApi.Models
 {
-    [ExportTsClass]
     public class Job
     {
         [Key]

--- a/RealtyReachApi/Models/JobProfessionalLink.cs
+++ b/RealtyReachApi/Models/JobProfessionalLink.cs
@@ -1,8 +1,7 @@
-using TypeGen.Core.TypeAnnotations;
+
 
 namespace RealtyReachApi.Models;
 
-[ExportTsClass]
 public class JobProfessionalLink
 {
     public int JobDetailId { get; set; } // Composite Key Part 1
@@ -12,6 +11,6 @@ public class JobProfessionalLink
     public DateTime AssignedDate { get; set; }
 
     // Navigation properties
-    public JobDetail JobDetail { get; set; }
-    public Professional Professional { get; set; }
+    // public JobDetail JobDetail { get; set; }
+    // public Professional Professional { get; set; }
 }

--- a/RealtyReachApi/Models/JobProfessionalLink.cs
+++ b/RealtyReachApi/Models/JobProfessionalLink.cs
@@ -11,6 +11,6 @@ public class JobProfessionalLink
     public DateTime AssignedDate { get; set; }
 
     // Navigation properties
-    // public JobDetail JobDetail { get; set; }
-    // public Professional Professional { get; set; }
+    public JobDetail JobDetail { get; set; }
+    public Professional Professional { get; set; }
 }

--- a/RealtyReachApi/Models/Professional.cs
+++ b/RealtyReachApi/Models/Professional.cs
@@ -1,10 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using TypeGen.Core.TypeAnnotations;
 
 namespace RealtyReachApi.Models;
-[ExportTsClass]
+
 public class Professional
 {
     public Guid Id { get; set; }

--- a/RealtyReachApi/Repositories/IJobRepository.cs
+++ b/RealtyReachApi/Repositories/IJobRepository.cs
@@ -10,4 +10,5 @@ public interface IJobRepository
     // Task<JobDetail?> GetJobDetailWithProfessionalTypesAsync(int jobId);
     Task<bool> UpdateJobAsync(Job? job);
     Task<bool> DeleteJobAsync(int jobId);
+    Task<JobProfessionalLink> MatchJobAsync(JobProfessionalLink jobProfessionalLink);
 }

--- a/RealtyReachApi/Repositories/JobRepository.cs
+++ b/RealtyReachApi/Repositories/JobRepository.cs
@@ -41,9 +41,20 @@ public class JobRepository : IJobRepository
         throw new NotImplementedException();
     }
 
-    public Task<bool> UpdateJobAsync(Job? job)
+    public async Task<bool> UpdateJobAsync(Job? job)
     {
-        throw new NotImplementedException();
+        if (job == null) {
+            return false;
+        }
+
+        var existingJob = await _context.Jobs.FindAsync(job.JobId);
+        if (existingJob == null) {
+            return false;
+        }
+
+        _context.Entry(existingJob).CurrentValues.SetValues(job);
+
+        return await _context.SaveChangesAsync() > 0;
     }
 
     public Task<bool> DeleteJobAsync(int jobId)
@@ -52,7 +63,7 @@ public class JobRepository : IJobRepository
     }
 
     public async Task<JobProfessionalLink> MatchJobAsync(JobProfessionalLink jobProfessionalLink) {
-        _context.JobProfessionalLinks.Add(jobProfessionalLink);
+        _context.JobProfessionalLink.Add(jobProfessionalLink);
         await _context.SaveChangesAsync();
         return jobProfessionalLink;
     }

--- a/RealtyReachApi/Repositories/JobRepository.cs
+++ b/RealtyReachApi/Repositories/JobRepository.cs
@@ -51,6 +51,12 @@ public class JobRepository : IJobRepository
         throw new NotImplementedException();
     }
 
+    public async Task<JobProfessionalLink> MatchJobAsync(JobProfessionalLink jobProfessionalLink) {
+        _context.JobProfessionalLinks.Add(jobProfessionalLink);
+        await _context.SaveChangesAsync();
+        return jobProfessionalLink;
+    }
+
     // public async Task<JobDetailDto?> GetJobDetailWithProfessionalTypesAsync(int jobId)
     // {
     //     var jobDetail = await _context.JobDetails

--- a/RealtyReachApi/Services/IMatchingService.cs
+++ b/RealtyReachApi/Services/IMatchingService.cs
@@ -1,3 +1,4 @@
+using RealtyReachApi.Dtos;
 using RealtyReachApi.Models;
 
 namespace RealtyReachApi.Services;
@@ -5,4 +6,5 @@ namespace RealtyReachApi.Services;
 public interface IMatchingService
 {
     Task<List<Professional>> IdentifySuitableProfessionalsAsync(string[] selectedProfessionals);
+    Task<bool> FinalizeMatchAsync(MatchingJobDto matchingJobDto);
 }

--- a/RealtyReachApi/Services/MatchingService.cs
+++ b/RealtyReachApi/Services/MatchingService.cs
@@ -58,6 +58,8 @@ public class MatchingService : IMatchingService
         if (tempJob != null) {
             jobProfessionalLink.JobDetailId = tempJob.JobDetails.JobDetailId;
             jobProfessionalLink.ProfessionalId = matchingJobDto.ProfessionalId;
+            jobProfessionalLink.AssignedDate = DateTime.UtcNow;
+            jobProfessionalLink.SelectionDate = DateTime.UtcNow;
             
             //TODO: Run db transaction to store the matches to JobProfessionalLink table
             await _jobRepository.MatchJobAsync(jobProfessionalLink);

--- a/RealtyReachApi/Services/MatchingService.cs
+++ b/RealtyReachApi/Services/MatchingService.cs
@@ -51,10 +51,25 @@ public class MatchingService : IMatchingService
     }
 
     //TODO: Get MatchingJobDto that has job id and selected professional id
-    public async Task<bool> FinalizeMatchAsync()
+    public async Task<bool> FinalizeMatchAsync(MatchingJobDto matchingJobDto)
     {
-        //TODO: Run db transaction to store the matches to JobProfessionalLink table
-        //TODO: Update the JobDetail SuggestedProfessionals attribute to remove matched professional id
-        throw new NotImplementedException();
+        Job? tempJob = await _jobRepository.GetJobByIdAsync(matchingJobDto.JobId);
+        JobProfessionalLink jobProfessionalLink = new JobProfessionalLink();
+        if (tempJob != null) {
+            jobProfessionalLink.JobDetailId = tempJob.JobDetails.JobDetailId;
+            jobProfessionalLink.ProfessionalId = matchingJobDto.ProfessionalId;
+            
+            //TODO: Run db transaction to store the matches to JobProfessionalLink table
+            await _jobRepository.MatchJobAsync(jobProfessionalLink);
+            
+            //TODO: Update the JobDetail SuggestedProfessionals attribute to remove matched professional id
+            tempJob.JobDetails.SuggestedProfessionalIds = Array.FindAll
+            (tempJob.JobDetails.SuggestedProfessionalIds, val => val != matchingJobDto.ProfessionalId);
+            await _jobRepository.UpdateJobAsync(tempJob);
+            return true;
+        }
+        else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Added the finalise match feature in matching service that adds job detail id and professional id to the JobProfessionalLink table. Also ensured that the professional has been removed from the suggested professional list.
Added endpoint called finalise in customer job controller to test that its working. Created a job with jobid = 3 and 3 professionals (2 advocates and 1 broker). Called the finalise end point. The db looks like this:

![image](https://github.com/user-attachments/assets/65649f05-9fd7-4588-b412-31bfee3e35f5)

Suggested Professionals list goes from 3 to 2. Not much error handling added though.

Sorry for the naming on this branch, had a brain freeze